### PR TITLE
Networking and simulation tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,3 +40,5 @@ RUN echo "source /root/catkin_ws/devel/setup.bash" >> ~/.bashrc
 ENV ROS_LOG_DIR /root/logs
 
 EXPOSE 3000
+
+RUN apt-get install -y net-tools iputils-ping

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,8 @@
-version: "3.9"
+version: "3.7"
 
 services:
   surface:
+    network_mode: host
     build: ./
     image: nautilus_surface
     container_name: surface
@@ -12,9 +13,6 @@ services:
       - "4040:4040"
     stdin_open: true
     tty: true
-    networks:
-      vlan:
-        ipv4_address: 420.69.0.1
     volumes:
       - type: volume
         source: nautilus_logs
@@ -25,18 +23,6 @@ services:
       - type: volume
         source: node_files
         target: /root/catkin_ws/src/uwrov_interface/node_modules
-
-networks:
-  dockervlan:
-    name: dockervlan
-    driver: macvlan
-    driver_opts:
-      parent: eth0
-    ipam:
-      config:
-        - subnet: "420.69.0.1/32"
-          gateway: "192.168.0.1"
-
 
 volumes:
   nautilus_logs:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,9 +13,10 @@ services:
     stdin_open: true
     tty: true
     networks:
-      - nautilus_network
+      vlan:
+        ipv4_address: 420.69.0.1
     volumes:
-      - type: volume 
+      - type: volume
         source: nautilus_logs
         target: /root/logs
       - type: bind
@@ -24,31 +25,18 @@ services:
       - type: volume
         source: node_files
         target: /root/catkin_ws/src/uwrov_interface/node_modules
-  sim:
-    profiles: ['sim']
-    build: ../nautilus_sim/
-    image: nautilus_sim
-    container_name: sim_surface
-    environment:
-      - "ROS_HOSTNAME=sim"
-      - "ROS_MASTER_URI=http://surface:11311"
-    ports:
-      - "8080:8080"
-    stdin_open: true
-    tty: true
-    networks:
-      - nautilus_network
-    volumes:
-      - type: bind
-        source: ../nautilus_sim/models/nautilus
-        target: /root/gzweb/http/client/assets/nautilus
-      - type: bind
-        source: ../nautilus_sim/nautilus_worlds
-        target: /root/catkin_ws/src/nautilus_worlds
 
 networks:
-  nautilus_network:
-    driver: bridge
+  dockervlan:
+    name: dockervlan
+    driver: macvlan
+    driver_opts:
+      parent: eth0
+    ipam:
+      config:
+        - subnet: "420.69.0.1/32"
+          gateway: "192.168.0.1"
+
 
 volumes:
   nautilus_logs:

--- a/local-compose.yaml
+++ b/local-compose.yaml
@@ -1,0 +1,29 @@
+services:
+  surface:
+    networks:
+      - nautilus_network
+  sim:
+      profiles: ['sim']
+      build: ../nautilus_sim/
+      image: nautilus_sim
+      container_name: sim_surface
+      environment:
+        - "ROS_HOSTNAME=sim"
+        - "ROS_MASTER_URI=http://surface:11311"
+      ports:
+        - "8080:8080"
+      stdin_open: true
+      tty: true
+      networks:
+        - nautilus_network
+      volumes:
+        - type: bind
+          source: ../nautilus_sim/models/nautilus
+          target: /root/gzweb/http/client/assets/nautilus
+        - type: bind
+          source: ../nautilus_sim/nautilus_worlds
+          target: /root/catkin_ws/src/nautilus_worlds
+
+networks:
+  nautilus_network:
+    driver: bridge

--- a/local-compose.yaml
+++ b/local-compose.yaml
@@ -1,5 +1,6 @@
 services:
   surface:
+    network_mode: bridge
     networks:
       - nautilus_network
   sim:

--- a/local-compose.yaml
+++ b/local-compose.yaml
@@ -1,13 +1,34 @@
 services:
   surface:
-    network_mode: bridge
     networks:
       - nautilus_network
+    build: ./
+    image: nautilus_surface
+    container_name: surface
+    hostname: surface
+    environment:
+      - "ROS_HOSTNAME=surface"
+    ports:
+      - "3000:3000"
+      - "4040:4040"
+    stdin_open: true
+    tty: true
+    volumes:
+      - type: volume
+        source: nautilus_logs
+        target: /root/logs
+      - type: bind
+        source: ./src
+        target: /root/catkin_ws/src
+      - type: volume
+        source: node_files
+        target: /root/catkin_ws/src/uwrov_interface/node_modules
   sim:
       profiles: ['sim']
       build: ../nautilus_sim/
       image: nautilus_sim
-      container_name: sim_surface
+      container_name: sim
+      hostname: sim
       environment:
         - "ROS_HOSTNAME=sim"
         - "ROS_MASTER_URI=http://surface:11311"
@@ -28,3 +49,9 @@ services:
 networks:
   nautilus_network:
     driver: bridge
+
+volumes:
+  nautilus_logs:
+    external: true
+  node_files:
+    external: true

--- a/src/nautilus_launch/launch/system.launch
+++ b/src/nautilus_launch/launch/system.launch
@@ -3,6 +3,6 @@
     <node name="server" pkg="uwrov_server" type="main_server.py" output="screen"/>
     <node name="interface" pkg="uwrov_interface" type="launch_interface.bash"/>
     
-    <node name="motors" pkg="nautilus_motors" type="motor_driver.py"/>
+    <node name="motors" pkg="nautilus_motors" type="motor_driver.py" output="screen"/>
   </group>
 </launch>

--- a/src/nautilus_motors/scripts/motor_driver.py
+++ b/src/nautilus_motors/scripts/motor_driver.py
@@ -22,7 +22,6 @@ def drive(wrench_msg, publisher):
     data = calculate_pwms(wrench_msg)
     msg = Int16MultiArray(layout=layout, data=data)
     publisher.publish(msg)
-
 # launch publisher and subscriber
 def main():
     print('starting publisher on', publish_topic)

--- a/src/nautilus_motors/src/MotorCode/Control.py
+++ b/src/nautilus_motors/src/MotorCode/Control.py
@@ -24,13 +24,16 @@ pin5 = 26
 pin6 = 12
 
 # scalers applied onto each motors, index 0 is motor A and index 5 is motor F
-motor_scalers = [0.25, -0.25, -0.25, 0.25, 0.25, 0.25]
+# motor_scalers = [0.25, -0.25, -0.25, 0.25, 0.25, 0.25]
+motor_scalers = [0.25, 0.25, 0.25, 0.25, 0.25, 0.25]
 
 
 # controlOutputs - array of pwms to set
 # idx - index of the array to set (0 -> A, 5->F)
 # c - motor constant, value in [-1,1] which scales output of motor, 
 #     0 is stop, -1 is full blast reverse, 1 is full blast forward
+
+# Assumes positive Y is forward, positive X is right, positive Z is up.
 def pwm_transform(controlOutputs, idx, c):
     global motor_scalers
     controlOutputs[idx] = (motor_scalers[idx] * slope * c) + intercept 
@@ -49,18 +52,18 @@ def calculate_pwms(controlInputs: Wrench) -> list:
         assert item >= -1 or item <= 1
 
     # flip inputs as needed
-    controlInputs[0] *= -1      # X 
-    controlInputs[1] *= 1      # Y
-    controlInputs[2] *= -1      # Z
-    controlInputs[3] *= 1      # R
+    # controlInputs[0] *= -1      # X 
+    # controlInputs[1] *= 1      # Y
+    # controlInputs[2] *= -1      # Z
+    # controlInputs[5] *= 1      # R
 
     # Case where there is no rotation based on the "R" value of the input array being zero.
-    if (controlInputs[3] == 0):
+    if (controlInputs[5] == 0):
         # calculate motor constants
-        Ac = 0.5 * (controlInputs[0] - controlInputs[1])
-        Bc = 0.5 * (controlInputs[0] + controlInputs[1])
-        Cc = 0.5 * (controlInputs[0] + controlInputs[1])
-        Dc = 0.5 * (controlInputs[0] - controlInputs[1])
+        Ac = 0.5 * (controlInputs[1] + controlInputs[0])
+        Bc = 0.5 * (controlInputs[1] - controlInputs[0])
+        Cc = 0.5 * (controlInputs[1] - controlInputs[0])
+        Dc = 0.5 * (controlInputs[1] + controlInputs[0])
         Ec = controlInputs[2]
         Fc = Ec
         
@@ -73,8 +76,8 @@ def calculate_pwms(controlInputs: Wrench) -> list:
         pwm_transform(controlOutputs, 5, Fc) 
     else:
         # rotation is clockwise based on a positive "R" value.
-        c1 = controlInputs[3] / 2
-        c2 = -1 * c1
+        c1 = controlInputs[5]
+        c2 = -1.0 * c1
         
         pwm_transform(controlOutputs, 0, c2)
         pwm_transform(controlOutputs, 1, c1)

--- a/src/uwrov_interface/src/components/xbox/Xbox.js
+++ b/src/uwrov_interface/src/components/xbox/Xbox.js
@@ -122,8 +122,8 @@ export default class Xbox extends React.Component {
     }
 
     this.vect = {
-      lin_x: this.state.LeftStickY,
-      lin_y: this.state.LeftStickX,
+      lin_x: this.state.LeftStickX,
+      lin_y: this.state.LeftStickY,
       lin_z: this.state.RightStickY,
       ang_x: 0,
       ang_y: 0,

--- a/src/uwrov_server/src/publishers/channel_pub.py
+++ b/src/uwrov_server/src/publishers/channel_pub.py
@@ -15,4 +15,4 @@ class ChannelPub(ServerPub):
     def publish(self, channel):
         rospy.loginfo("Changing channel to %d", channel)
         self.msg.data = channel
-        self.channel.publish(self.msg)
+        self.publisher.publish(self.msg)


### PR DESCRIPTION
`docker-compose up` will default to launching the surface container for the actual ROV.

To launch the container in a local-only test, run `docker-compose -f local-compose.yaml up`, or `docker-compose -f local-compose.yaml --profile sim up`